### PR TITLE
Additional gems to prevent some issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Semantic empowers designers and developers by creating a language for sharing UI
 Homepage: http://semantic-ui.com/
 
 ## Installation
-Inside your Gemfile add the following line:
+Inside your Gemfile add the following lines:
 ```ruby
+gem 'therubyracer', platforms: :ruby # or any other runtime
+gem 'less-rails'
 gem 'semantic-ui-rails'
 ```
-Then run `bundle install` to install the gem.
+Then run `bundle install` to install gems.
 
 Run generator to include assets to your project
 ```bash


### PR DESCRIPTION
I tried to generate new Rails 4 app and added the 'semantic-ui-rails' gem. It lead me to this error:
WARN: tilt autoloading 'less' in a non thread-safe way; explicit require 'less' suggested.
After I add gem 'less-rails' it worked ok.

gem 'therubyracer', platforms: :ruby added because it was an error with v8 library.
